### PR TITLE
build docker image when pushed to deployment branch

### DIFF
--- a/.github/workflows/build-external.yml
+++ b/.github/workflows/build-external.yml
@@ -6,7 +6,7 @@ defaults:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ deployment ]
 
 jobs:
   build:

--- a/.github/workflows/build-internal.yml
+++ b/.github/workflows/build-internal.yml
@@ -6,7 +6,7 @@ defaults:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ deployment ]
 
 jobs:
   build:


### PR DESCRIPTION
mainにpushするたびにdockerイメージ作るのやめたほうがよくね