### PR TITLE
implement speed control

### DIFF
--- a/backend/builtin/speed/internal/controlRaspSpeed.go
+++ b/backend/builtin/speed/internal/controlRaspSpeed.go
@@ -1,5 +1,33 @@
 package internal
 
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
 type RaspberrySpeed struct {
-	speed int
+	speed int32
+}
+
+var endPoint = "http://localhost:8081"
+
+func NewRaspberrySpeed(speed int32) *RaspberrySpeed {
+	return &RaspberrySpeed{speed: speed}
+}
+
+func (r *RaspberrySpeed) changeSpeed() error {
+	u, err := url.Parse(endPoint)
+	if err != nil {
+		log.Fatalln("URL Parse Err")
+	}
+	u.Query().Set("speed", string(r.speed))
+
+	res, err := http.Get(u.String())
+
+	if !(200 <= res.StatusCode && res.StatusCode < 300) {
+		return fmt.Errorf("GET Err is \"%w\" ;status is not Success", err)
+	}
+	return err
 }

--- a/backend/builtin/speed/internal/serveSpeedControl.go
+++ b/backend/builtin/speed/internal/serveSpeedControl.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "ueckoken/plarail2021-soft-builtin/spec"
 )
 
@@ -13,5 +15,11 @@ func NewServeSpeedControl() *ServeSpeedControl {
 	return &ServeSpeedControl{}
 }
 func (s *ServeSpeedControl) ControlSpeed(ctx context.Context, ss *pb.SendSpeed) (*pb.StatusCode, error) {
+	rs := NewRaspberrySpeed(ss.Speed)
+	err := rs.changeSpeed()
+	if err != nil {
+		return nil,
+			status.Errorf(codes.Unavailable, "grpc; %e", err)
+	}
 	return &pb.StatusCode{}, nil
 }


### PR DESCRIPTION
ラズパイの速度制御をgRPC経由で出来るようにしました。

ラズパイ上に載せたGo プログラムがラズパイ上にPythonで立てたHTTPサーバに対してGETリクエストを飛ばし、PythonサーバがGPIOを制御するようにした