### PR TITLE
disable image optimization

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "@next/next/no-img-element": "off" // no need to image optimization
+  }
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import Image from 'next/image'
 import styles from '../styles/Home.module.css'
 
 const Home: NextPage = () => {
@@ -61,7 +60,7 @@ const Home: NextPage = () => {
         >
           Powered by{' '}
           <span className={styles.logo}>
-            <Image src="/vercel.svg" alt="Vercel Logo" width={72} height={16} />
+            <img src="/vercel.svg" alt="Vercel Logo" width={72} height={16} />
           </span>
         </a>
       </footer>


### PR DESCRIPTION
ref: #147 

[画像の最適化がStatic HTML Exportの障壁になっている](https://github.com/ueckoken/plarail2021-soft/issues/147#issuecomment-965272684)とのことでしたが、この機能はそこまで重要ではないと思ったのでオフにしてみました。